### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 
 The MCP Todo.txt Integration is a server implementation of the Model Context Protocol (MCP) that enables interaction with Todo.txt files. This project allows LLMs to manage tasks in a Todo.txt file programmatically using the MCP protocol.
 
+<a href="https://glama.ai/mcp/servers/@guifelix/mcp-server-todotxt">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@guifelix/mcp-server-todotxt/badge" alt="Todo.txt Integration MCP server" />
+</a>
+
 ## Features
 
 ### Core Features


### PR DESCRIPTION
This PR adds a badge for the [MCP Todo.txt Integration](https://glama.ai/mcp/servers/@guifelix/mcp-server-todotxt) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@guifelix/mcp-server-todotxt">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@guifelix/mcp-server-todotxt/badge" alt="Todo.txt Integration MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.